### PR TITLE
Use node-cache to limit number of database queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-mongoose-store",
-  "version": "1.0.4",
+  "version": "1.0.6",
   "description": "Session store for people who want to use MongoDB sessions, and already have a MongooseJS connection for their backend.",
   "main": "./index.js",
   "repository": {
@@ -33,6 +33,7 @@
     "chai": "^1.9.1",
     "mocha": "^1.18.2",
     "express-session": "^1.0.4",
-    "mongoose": "^3.8.9"
+    "mongoose": "^3.8.9",
+    "node-cache": "^4.1.0"
   }
 }


### PR DESCRIPTION
Hi @battlejj, although mongo is good for the persistent storage we figured that it creates a bit of overhead to access the db on every request. Therefore I added a little memory caching (by using https://www.npmjs.com/package/node-cache).

Please publish the update on npm after merging!